### PR TITLE
Add theme download and CSS variable update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Follow these instructions to set up and use the Obsidian Theme Creator web app.
 
 - Use the input elements in the "Customize Your Theme" section to adjust the primary color, secondary color, accent color, font family, and font size.
 - The changes will be reflected in real-time in the "Theme Preview" section.
+- When you are happy with the result, use the **Download Theme** button to save a CSS file that can be loaded in Obsidian.
 
 ### Built With
 

--- a/my-obsidian-theme-app/src/App.js
+++ b/my-obsidian-theme-app/src/App.js
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ThemePreview from './ThemePreview';
 import ThemeControls from './ThemeControls';
-import './App.css';
 
 function App() {
   const [theme, setTheme] = useState({
@@ -19,13 +18,21 @@ function App() {
     }));
   };
 
+  useEffect(() => {
+    const root = document.documentElement;
+    Object.entries(theme).forEach(([key, value]) => {
+      const cssVar = `--${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
+      root.style.setProperty(cssVar, value);
+    });
+  }, [theme]);
+
   return (
     <div className="App">
       <header className="App-header">
         <h1>Obsidian Theme Creator</h1>
       </header>
       <main>
-        <ThemePreview theme={theme} />
+        <ThemePreview />
         <ThemeControls theme={theme} updateTheme={updateTheme} />
       </main>
     </div>

--- a/my-obsidian-theme-app/src/ThemeControls.js
+++ b/my-obsidian-theme-app/src/ThemeControls.js
@@ -3,14 +3,18 @@ import React from 'react';
 const ThemeControls = ({ theme, updateTheme }) => {
   const handleInputChange = (e) => {
     const { name, value } = e.target;
- fix-theme-customization
-    updateTheme((prevTheme) => ({
-      ...prevTheme,
-      [name]: value,
-    }));
-
     updateTheme(name, value);
-    main
+  };
+
+  const downloadTheme = () => {
+    const css = `:root {\n  --primary-color: ${theme.primaryColor};\n  --secondary-color: ${theme.secondaryColor};\n  --accent-color: ${theme.accentColor};\n  --font-family: ${theme.fontFamily};\n  --font-size: ${theme.fontSize};\n}`;
+    const blob = new Blob([css], { type: 'text/css' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'obsidian-theme.css';
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   return (
@@ -63,6 +67,7 @@ const ThemeControls = ({ theme, updateTheme }) => {
           max="36"
           onChange={handleInputChange}
         />
+        <button type="button" onClick={downloadTheme}>Download Theme</button>
       </form>
     </div>
   );

--- a/my-obsidian-theme-app/src/ThemePreview.js
+++ b/my-obsidian-theme-app/src/ThemePreview.js
@@ -1,10 +1,8 @@
 import React from 'react';
 
-const ThemePreview = ({ theme }) => {
-  const { primaryColor, secondaryColor, accentColor, fontFamily, fontSize } = theme;
-
+const ThemePreview = () => {
   return (
-    <section id="preview-area" style={theme}>
+    <section id="preview-area">
       <h2>Theme Preview</h2>
       <div id="preview">
         <p>This is a preview of your theme.</p>

--- a/my-obsidian-theme-app/src/index.css
+++ b/my-obsidian-theme-app/src/index.css
@@ -16,6 +16,17 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+#preview-area {
+  padding: 1rem;
+}
+
+#preview {
+  border: 1px solid var(--primary-color);
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  padding: 1rem;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;


### PR DESCRIPTION
## Summary
- fix theme control handler and add download button
- sync theme state to CSS variables
- clean preview component
- add simple preview styles
- document download step in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68475ac1811083288e66742150eb1de9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a “Download Theme” button to export the current theme as a CSS file.

* Refactor
  * Live theme updates now apply via CSS variables for a more consistent preview.
  * Theme preview no longer requires props and renders a static preview area.

* Style
  * Updated preview styling with themed border, colors, and padding.
  * Removed a legacy font-smoothing rule.

* Documentation
  * README now includes instructions to download the generated CSS using the “Download Theme” button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->